### PR TITLE
Added StringDef annotations to focus and flash mode setters

### DIFF
--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
@@ -37,6 +37,8 @@ import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.Frame;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.Thread.State;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
@@ -25,6 +25,7 @@ import android.hardware.Camera.CameraInfo;
 import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.RequiresPermission;
+import android.support.annotation.StringDef;
 import android.util.Log;
 import android.view.Surface;
 import android.view.SurfaceHolder;
@@ -85,6 +86,28 @@ public class CameraSource {
      * ratio is less than this tolerance, they are considered to be the same aspect ratio.
      */
     private static final float ASPECT_RATIO_TOLERANCE = 0.01f;
+    
+    @StringDef({
+        Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE,
+        Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO,
+        Camera.Parameters.FOCUS_MODE_AUTO,
+        Camera.Parameters.FOCUS_MODE_EDOF,
+        Camera.Parameters.FOCUS_MODE_FIXED,
+        Camera.Parameters.FOCUS_MODE_INFINITY,
+        Camera.Parameters.FOCUS_MODE_MACRO
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    private @interface FocusMode {}
+    
+    @StringDef({
+        Camera.Parameters.FLASH_MODE_ON,
+        Camera.Parameters.FLASH_MODE_OFF,
+        Camera.Parameters.FLASH_MODE_AUTO,
+        Camera.Parameters.FLASH_MODE_RED_EYE,
+        Camera.Parameters.FLASH_MODE_TORCH
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    private @interface FlashMode {}
 
     private Context mContext;
 
@@ -172,12 +195,12 @@ public class CameraSource {
             return this;
         }
 
-        public Builder setFocusMode(String mode) {
+        public Builder setFocusMode(@FocusMode String mode) {
             mCameraSource.mFocusMode = mode;
             return this;
         }
 
-        public Builder setFlashMode(String mode) {
+        public Builder setFlashMode(@FlashMode String mode) {
             mCameraSource.mFlashMode = mode;
             return this;
         }


### PR DESCRIPTION
This addition to the original code allows the IDE to verify if the developer supported an appropriate string as focus / flash mode.