### PR TITLE
Clear mBytesToByteBuffer to prevent out of memory exceptions

### DIFF
--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
@@ -408,6 +408,9 @@ public class CameraSource {
                 mProcessingThread = null;
             }
 
+            // clear the buffer to prevent oom exceptions
+            mBytesToByteBuffer.clear();
+
             if (mCamera != null) {
                 mCamera.stopPreview();
                 mCamera.setPreviewCallbackWithBuffer(null);


### PR DESCRIPTION
Currently when stopping and starting the camera multiple times on the same screen you will run into a OOM exception because mBytesToByteBuffer grows by each start. Clearing the buffer when stoping prevents this.