### PR TITLE
Adding ability to consume barcodes in BarcodeCaptureActivity

### DIFF
--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeCaptureActivity.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeCaptureActivity.java
@@ -57,7 +57,7 @@ import java.io.IOException;
  * rear facing camera. During detection overlay graphics are drawn to indicate the position,
  * size, and ID of each barcode.
  */
-public final class BarcodeCaptureActivity extends AppCompatActivity {
+public final class BarcodeCaptureActivity extends AppCompatActivity implements BarcodeGraphicTracker.BarcodeUpdateListener {
     private static final String TAG = "Barcode-reader";
 
     // intent request code to handle updating play services if needed.
@@ -170,7 +170,7 @@ public final class BarcodeCaptureActivity extends AppCompatActivity {
         // graphics for each barcode on screen.  The factory is used by the multi-processor to
         // create a separate tracker instance for each barcode.
         BarcodeDetector barcodeDetector = new BarcodeDetector.Builder(context).build();
-        BarcodeTrackerFactory barcodeFactory = new BarcodeTrackerFactory(mGraphicOverlay);
+        BarcodeTrackerFactory barcodeFactory = new BarcodeTrackerFactory(mGraphicOverlay, this);
         barcodeDetector.setProcessor(
                 new MultiProcessor.Builder<>(barcodeFactory).build());
 
@@ -427,5 +427,10 @@ public final class BarcodeCaptureActivity extends AppCompatActivity {
         public void onScaleEnd(ScaleGestureDetector detector) {
             mCameraSource.doZoom(detector.getScaleFactor());
         }
+    }
+
+    @Override
+    public void onBarcodeDetected(Barcode barcode) {
+        //do something with barcode data returned
     }
 }

--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeGraphicTracker.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeGraphicTracker.java
@@ -15,6 +15,9 @@
  */
 package com.google.android.gms.samples.vision.barcodereader;
 
+import android.content.Context;
+import android.support.annotation.UiThread;
+
 import com.google.android.gms.samples.vision.barcodereader.ui.camera.GraphicOverlay;
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.Tracker;
@@ -26,13 +29,30 @@ import com.google.android.gms.vision.barcode.Barcode;
  * to an overlay, update the graphics as the item changes, and remove the graphics when the item
  * goes away.
  */
-class BarcodeGraphicTracker extends Tracker<Barcode> {
+public class BarcodeGraphicTracker extends Tracker<Barcode> {
     private GraphicOverlay<BarcodeGraphic> mOverlay;
     private BarcodeGraphic mGraphic;
 
-    BarcodeGraphicTracker(GraphicOverlay<BarcodeGraphic> overlay, BarcodeGraphic graphic) {
-        mOverlay = overlay;
-        mGraphic = graphic;
+    private BarcodeUpdateListener mBarcodeUpdateListener;
+
+    /**
+     * Consume the item instance detected from an Activity or Fragment level by implementing the
+     * BarcodeUpdateListener interface method onBarcodeDetected.
+     */
+    public interface BarcodeUpdateListener {
+        @UiThread
+        void onBarcodeDetected(Barcode barcode);
+    }
+
+    BarcodeGraphicTracker(GraphicOverlay<BarcodeGraphic> mOverlay, BarcodeGraphic mGraphic,
+                          Context context) {
+        this.mOverlay = mOverlay;
+        this.mGraphic = mGraphic;
+        if (context instanceof BarcodeUpdateListener) {
+            this.mBarcodeUpdateListener = (BarcodeUpdateListener) context;
+        } else {
+            throw new RuntimeException("Hosting activity must implement BarcodeUpdateListener");
+        }
     }
 
     /**
@@ -41,6 +61,7 @@ class BarcodeGraphicTracker extends Tracker<Barcode> {
     @Override
     public void onNewItem(int id, Barcode item) {
         mGraphic.setId(id);
+        mBarcodeUpdateListener.onBarcodeDetected(item);
     }
 
     /**

--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeTrackerFactory.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/BarcodeTrackerFactory.java
@@ -15,6 +15,8 @@
  */
 package com.google.android.gms.samples.vision.barcodereader;
 
+import android.content.Context;
+
 import com.google.android.gms.samples.vision.barcodereader.ui.camera.GraphicOverlay;
 import com.google.android.gms.vision.MultiProcessor;
 import com.google.android.gms.vision.Tracker;
@@ -26,15 +28,18 @@ import com.google.android.gms.vision.barcode.Barcode;
  */
 class BarcodeTrackerFactory implements MultiProcessor.Factory<Barcode> {
     private GraphicOverlay<BarcodeGraphic> mGraphicOverlay;
+    private Context mContext;
 
-    BarcodeTrackerFactory(GraphicOverlay<BarcodeGraphic> barcodeGraphicOverlay) {
-        mGraphicOverlay = barcodeGraphicOverlay;
+    public BarcodeTrackerFactory(GraphicOverlay<BarcodeGraphic> mGraphicOverlay,
+                                 Context mContext) {
+        this.mGraphicOverlay = mGraphicOverlay;
+        this.mContext = mContext;
     }
 
     @Override
     public Tracker<Barcode> create(Barcode barcode) {
         BarcodeGraphic graphic = new BarcodeGraphic(mGraphicOverlay);
-        return new BarcodeGraphicTracker(mGraphicOverlay, graphic);
+        return new BarcodeGraphicTracker(mGraphicOverlay, graphic, mContext);
     }
 
 }


### PR DESCRIPTION
Hi Google Team!

I tinkered with the camera’s barcode detection and scanning capabilities in order to create the [ScannerApp](https://github.com/AdamSHurwitz/ScannerApp) sample showcasing smooth transitioning between barcode scanning modes while keeping the camera running. This results in seamless toggling between barcode types which is also useful for switching between any type of camera detection.

This commit reflects a portion of the modifications I made to the Google Vision sample app in order to return the barcode results on the Activity level via an interface. This allows seamless toggling between scanner types in the [ScannerApp](https://github.com/AdamSHurwitz/ScannerApp)  because then the returned data is passed down to the child ViewPager to show for the corresponding scanner view.

Here is a more [in-depth breakdown](https://medium.com/@AdamHurwitz/seamless-tracker-toggling-android-camera2-f65ea0e6f2c3) of this use case. I have conducted manual QA testing and do not see any UI bugs or errors in the logs. I'd love your feedback. 

Thanks!

Adam