### PR TITLE
Fix take picture with low resolution

### DIFF
--- a/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
+++ b/visionSamples/barcode-reader/app/src/main/java/com/google/android/gms/samples/vision/barcodereader/ui/camera/CameraSource.java
@@ -909,6 +909,12 @@ public class CameraSource {
                 parameters.getSupportedPreviewSizes();
         List<android.hardware.Camera.Size> supportedPictureSizes =
                 parameters.getSupportedPictureSizes();
+
+        int lastIndex = supportedPictureSizes.size() - 1;
+        if (supportedPictureSizes.get(0).height < supportedPictureSizes.get(lastIndex).height) {
+            Collections.reverse(supportedPictureSizes);
+        }
+
         List<SizePair> validPreviewSizes = new ArrayList<>();
         for (android.hardware.Camera.Size previewSize : supportedPreviewSizes) {
             float previewAspectRatio = (float) previewSize.width / (float) previewSize.height;


### PR DESCRIPTION
Some device list their support picture size from lowest to highest, make sure `supportedPictureSizes` started from highest resolution to fix #19 