### PR TITLE
Rearrange snackbar msgs to avoid overlapping each other

### DIFF
--- a/visionSamples/ocr-reader/app/src/main/java/com/google/android/gms/samples/vision/ocrreader/OcrCaptureActivity.java
+++ b/visionSamples/ocr-reader/app/src/main/java/com/google/android/gms/samples/vision/ocrreader/OcrCaptureActivity.java
@@ -97,16 +97,17 @@ public final class OcrCaptureActivity extends AppCompatActivity {
         int rc = ActivityCompat.checkSelfPermission(this, Manifest.permission.CAMERA);
         if (rc == PackageManager.PERMISSION_GRANTED) {
             createCameraSource(autoFocus, useFlash);
+			
+			Snackbar.make(mGraphicOverlay, "Tap to capture. Pinch/Stretch to zoom",
+                Snackbar.LENGTH_LONG)
+                .show();
+			
         } else {
             requestCameraPermission();
         }
 
         gestureDetector = new GestureDetector(this, new CaptureGestureListener());
         scaleGestureDetector = new ScaleGestureDetector(this, new ScaleListener());
-
-        Snackbar.make(mGraphicOverlay, "Tap to capture. Pinch/Stretch to zoom",
-                Snackbar.LENGTH_LONG)
-                .show();
     }
 
     /**
@@ -267,6 +268,10 @@ public final class OcrCaptureActivity extends AppCompatActivity {
             boolean autoFocus = getIntent().getBooleanExtra(AutoFocus,false);
             boolean useFlash = getIntent().getBooleanExtra(UseFlash, false);
             createCameraSource(autoFocus, useFlash);
+			
+			Snackbar.make(mGraphicOverlay, "Tap to capture. Pinch/Stretch to zoom",
+                Snackbar.LENGTH_LONG)
+                .show();
             return;
         }
 


### PR DESCRIPTION
The overlapping is seen when user denies Camera Permission and clicks on "Detect Text." The snackbar with message "Tap to capture. Pinch/Stretch to zoom" overlaps with the snackbar's message "Access to the camera is needed for detection." As a result, user is unable to press "OK" to request permission again.